### PR TITLE
feat: 实现setStrings方法适配Harmony OS

### DIFF
--- a/harmony/clipboard/src/main/ets/RNCClipboardTurboModule.ts
+++ b/harmony/clipboard/src/main/ets/RNCClipboardTurboModule.ts
@@ -319,21 +319,25 @@ export class RNCClipboardTurboModule extends TurboModule {
   setStrings(content: string[]) {
     logger.debug(TAG, "[RNOH]:RNCClipboardTurboModule call setStrings fun");
     let systemPasteboard = pasteboard.getSystemPasteboard();
-    systemPasteboard.getData().then((pasteData) => {
-      for (let i = 0; i < content.length; i++) {
-        pasteData.addRecord(pasteboard.MIMETYPE_TEXT_PLAIN, content[i]);
-        logger.debug(TAG, `[RNOH]:setStrings,PasteData--addRecord:${content[i]}`);
-      }
+    systemPasteboard.clear().then(() => {
+      systemPasteboard.getData().then((pasteData) => {
+        for (let i = 0; i < content.length; i++) {
+          pasteData.addRecord(pasteboard.MIMETYPE_TEXT_PLAIN, content[i]);
+          logger.debug(TAG, `[RNOH]:setStrings,PasteData--addRecord:${content[i]}`);
+        }
 
-      // setData
-      systemPasteboard.setData(pasteData).then((data: void) => {
-        logger.debug(TAG, "setStrings,Succeeded in setting PasteData.");
+        // setData
+        systemPasteboard.setData(pasteData).then((data: void) => {
+          logger.debug(TAG, "setStrings,Succeeded in setting PasteData.");
+        }).catch((err) => {
+          logger.error(TAG, `setStrings,Failed to set PasteData. Cause:${err.message}`);
+        });
       }).catch((err) => {
-        logger.error(TAG, `setStrings,Failed to set PasteData. Cause:${err.message}`);
-      });
-    }).catch((err) => {
-      logger.error(TAG, `setStrings,getData error,Cause:${err.message}`);
-    })
+        logger.error(TAG, `setStrings,getData error,Cause:${err.message}`);
+      })
+    }).catch((err: BusinessError) => {
+      console.error(`Failed to clear the PasteData. Cause: ${err.message}`);
+    });
     return;
   }
 


### PR DESCRIPTION
# Summary

- Closes #13 
- 实现setStrings方法适配Harmony OS
- setStrings在iOS是独有的属性，Harmony OS调用剪贴板能力先清除剪贴板内容再向剪贴板内容中添加多条条目


## Test Plan

调用setStrings方法


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [X] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->
